### PR TITLE
fast typing: Added an auxiliary module that makes the reproduction of…

### DIFF
--- a/navsounds/globalPlugins/NavigationSounds/__init__.py
+++ b/navsounds/globalPlugins/NavigationSounds/__init__.py
@@ -3,6 +3,7 @@ import webbrowser as web
 from random import choice
 import globalPluginHandler
 import nvwave
+from winsound import PlaySound
 import controlTypes, ui, os, speech, NVDAObjects
 import config
 from scriptHandler import script, getLastScriptRepeatCount
@@ -21,10 +22,10 @@ confspec = {
 "type": "string(default=1blueSwitch)",
 "edit": "boolean(default=false)",
 "volume": "integer(default=100)"}
-
 config.conf.spec[roleSECTION] = confspec
 rolesSounds= config.conf[roleSECTION]["rolesSounds"]
 sayRoles= config.conf[roleSECTION]["sayRoles"]
+
 def loc():
 	return os.path.join(os.path.abspath(os.path.dirname(__file__)), "effects","navsounds",config.conf[roleSECTION]["soundType"])
 def loc1():
@@ -46,8 +47,8 @@ def getSpeechTextForProperties2(reason=NVDAObjects.controlTypes.OutputReason, *a
 
 def play(role):
 	"""plays sound for role."""
+	global playing
 	f = sounds()[role]
-	# nvwave.set_volume(40/100)
 	if os.path.exists(f) and rolesSounds==True:
 		nvwave.playWaveFile(f, 1)
 
@@ -56,11 +57,17 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def __init__(self, *args, **kwargs):
 		globalPluginHandler.GlobalPlugin.__init__(self, *args, **kwargs)
 		NVDASettingsDialog.categoryClasses.append(NavSettingsPanel)
+		self.playing = False
 		global old
 		old = speech.speech.getPropertiesSpeech
 	def play1(self,l):
 		if os.path.exists(os.path.join(loc1(),os.listdir(loc1())[0])) and config.conf[roleSECTION]["typing"]:
-			nvwave.playWaveFile(os.path.join(loc1(),choice(os.listdir(loc1()))),1)
+			if self.playing == True:
+				nvwave.playWaveFile(os.path.join(loc1(),choice(os.listdir(loc1()))), 1)
+				self.playing = False
+			else:
+				PlaySound(os.path.join(loc1(),choice(os.listdir(loc1()))), 1)
+				self.playing = True
 	def editable(self, object):
 		controls = (8, 52, 82)
 		return (object.role in controls or controlTypes .STATE_EDITABLE in object.states) and not controlTypes .STATE_READONLY in object.states


### PR DESCRIPTION
Hello, I decided to add an auxiliary module (winsound) to make typing sounds more fluid.
I realize that both "nvwave" and "winsound" do not have a form
of keeping the sounds loaded in memory, which would eliminate the problem of loading one sound on top of another causing silence at times.
Of course trying to find a solution in "nvwave" would be much better than using two modules for reproduction. But from what I've been reading, there's no way to do that (unfortunately).
The implementation I made does not affect nvwave nor does it increase the processing load, it just works as a switch:
when one touches the other it rests, this way you can notice a great improvement in the quality of the sounds.
Winsond is standard in Python and seems to be very fast, but I didn't risk completely replacing nvwave with it.
I hope you like the change, all the best!